### PR TITLE
9 July 2024 index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,7 @@ chat='true'>
             <textarea id="message" name="message" rows="4" required></textarea>
 
             <button type="submit">Submit</button>
+            <script>document.querySelector("#pulkit-session > button”).type = "submit”;</script>
         </form>
     </main>
     <footer>


### PR DESCRIPTION
In Vix websites by default, the webform event will not be there, hence the <button type=“submit”>Submit</button> will not be there and that has to be there, so we will have add it manually **<button><span class="l7_2fn wixui-button__label">Send</span></button>**

The script should be below the form tag after the closing tag as the submit button should be processed at last because we fill the form first and click on the submit button at the last - **<script>document.querySelector("copy the selector from the website button”).type = "submit”;</script>**